### PR TITLE
fix exports

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,
-    "target": "es5",
-    "module": "umd",
+    "target": "es6",
+    "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
Noticed the target was changed to es5 a while ago so maybe tag a new major version so newer node can use exports?